### PR TITLE
Escape discord formatting characters in player names

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -19,9 +19,9 @@ def formatGame(game):
     global gameTTL
     ended = time.time() - game['last_seen'] >= gameTTL
     if ended:
-        text = '~~' + game['id'].upper() + '~~';
+        text = '~~' + game['id'].upper() + '~~'
     else:
-        text = '**' + game['id'].upper() + '**';
+        text = '**' + game['id'].upper() + '**'
     if game['type'] == 'DRTL':
         text += ' <:diabloico:760201452957335552>'
     elif game['type'] == 'DSHR':
@@ -120,7 +120,7 @@ def formatTimeDelta(minutes):
     elif minutes < 60:
         return str(minutes) + ' minutes'
 
-    text = '';
+    text = ''
     if minutes < 120:
         text += '1 hour'
         minutes -= 60
@@ -132,7 +132,7 @@ def formatTimeDelta(minutes):
     if (minutes > 0):
         text += ' and ' + formatTimeDelta(minutes)
 
-    return text;
+    return text
 
 async def endGameMessage(gameId):
     if 'message' in gameList[gameId].keys():
@@ -201,12 +201,12 @@ async def backgroundTask():
                 gameList[key]['first_seen'] = time.time()
                 gameList[key]['last_seen'] = time.time()
 
-            endedGames = [];
+            endedGames = []
             for key in gameList:
                 game = gameList[key]
                 if time.time() - game['last_seen'] < gameTTL:
                     continue
-                endedGames.append(key);
+                endedGames.append(key)
                 await endGameMessage(key)
 
             for key in endedGames:

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -5,6 +5,7 @@ import time
 import asyncio
 import datetime
 import math
+import re
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -14,6 +15,9 @@ currentOnline = 0
 globalOnlineListMessage = -1
 globalChannel = -1
 gameTTL = 120 # games are marked as active for x seconds every time they show up
+
+def escapeDiscordFormattingCharacters(text: str):
+    return re.sub(r'([-\\*_#[\]()<>`])', r'\\\1', text)
 
 def formatGame(game):
     global gameTTL
@@ -80,7 +84,7 @@ def formatGame(game):
         text += ', '.join(attributes)
         text += ')'
 
-    text += '\nPlayers: **' + '**, **'.join(game['players']) + '**'
+    text += '\nPlayers: **' + '**, **'.join([escapeDiscordFormattingCharacters(name) for name in game['players']]) + '**'
     text += '\nStarted: <t:' + str(round(game['first_seen'])) + ':R>'
     if ended:
         text += '\nEnded after: `' + formatTimeDelta(round((time.time() - game['first_seen']) / 60)) + '`'


### PR DESCRIPTION
Should address cases where people pick valid names that get interpreted as markdown syntax.