### PR TITLE
Add spoiler and strikethrough metacharacters to escaped chars

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -17,7 +17,7 @@ globalChannel = -1
 gameTTL = 120 # games are marked as active for x seconds every time they show up
 
 def escapeDiscordFormattingCharacters(text: str):
-    return re.sub(r'([-\\*_#[\]()<>`])', r'\\\1', text)
+    return re.sub(r'([-\\*_#|~[\]()<>`])', r'\\\1', text)
 
 def formatGame(game):
     global gameTTL


### PR DESCRIPTION
forgot this one originally, people could trigger spoiler tags by starting and ending their name with two pipes