### PR TITLE
Add colon and at metacharacters to escaped chars

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -17,7 +17,7 @@ globalChannel = -1
 gameTTL = 120 # games are marked as active for x seconds every time they show up
 
 def escapeDiscordFormattingCharacters(text: str):
-    return re.sub(r'([-\\*_#|~[\]()<>`])', r'\\\1', text)
+    return re.sub(r'([-\\*_#|~:@[\]()<>`])', r'\\\1', text)
 
 def formatGame(game):
     global gameTTL


### PR DESCRIPTION
Reviewed this list of characters one more time after seeing the previous PR merged. We missed some important ones. Colon is for emojis, and at is for mentions.

There's also forward slash, but I don't think we need to escape it. It's used at the beginning of a message for some special handling, but player names should always be placed in the middle of the bot's message.