### PR TITLE
Use key in dict test directly, iterate over items

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -109,7 +109,7 @@ async def updateStatusMessage():
 async def updateGameMessage(gameId):
     global globalChannel
     text = formatGame(gameList[gameId])
-    if 'message' in gameList[gameId].keys():
+    if 'message' in gameList[gameId]:
         if (gameList[gameId]['message'].content != text):
             try:
                 await gameList[gameId]['message'].edit(content=text)
@@ -139,7 +139,7 @@ def formatTimeDelta(minutes):
     return text
 
 async def endGameMessage(gameId):
-    if 'message' in gameList[gameId].keys():
+    if 'message' in gameList[gameId]:
         try:
             await gameList[gameId]['message'].edit(content=formatGame(gameList[gameId]))
         except discord.errors.NotFound:
@@ -147,7 +147,7 @@ async def endGameMessage(gameId):
 
 async def removeGameMessages(gameIds):
     for gameId in gameIds:
-        if 'message' in gameList[gameId].keys():
+        if 'message' in gameList[gameId]:
             try:
                 await gameList[gameId]['message'].delete()
             except discord.errors.NotFound:
@@ -214,8 +214,7 @@ async def backgroundTask():
                     continue
 
                 key = game['id'].upper()
-                if key in gameList.keys():
-                    del gameList[key]['players']
+                if key in gameList:
                     gameList[key]['players'] = game['players']
                     gameList[key]['last_seen'] = time.time()
                     continue
@@ -225,8 +224,7 @@ async def backgroundTask():
                 gameList[key]['last_seen'] = time.time()
 
             endedGames = []
-            for key in gameList:
-                game = gameList[key]
+            for key, game in gameList.items():
                 if time.time() - game['last_seen'] < gameTTL:
                     continue
                 endedGames.append(key)


### PR DESCRIPTION
The more usual way of testing for a keys existence in a dictionary is to use `key in dict` directly, not testing for membership in the key view returned by `.keys()`. There was also a loop that can be made simpler by using the `.items()` view to iterate over `key,value` pairs instead of needing to do a lookup.

Also didn't seem like deleting the old list of players was really necessary, the only thing that would do is trigger a KeyError if a previous iteration had somehow managed to load a json file without the players key (even if there was somehow a game with no players the c++ program should still write the key in the object with a null value).