### PR TITLE
Remove cmake 3.24 feature

### DIFF
--- a/3rdParty/nlohmann_json/CMakeLists.txt
+++ b/3rdParty/nlohmann_json/CMakeLists.txt
@@ -3,6 +3,5 @@ include(FetchContent)
 FetchContent_Declare(json
 	URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
 	URL_HASH SHA256=8c4b26bf4b422252e13f332bc5e388ec0ab5c3443d24399acb675e68278d341f
-	DOWNLOAD_EXTRACT_TIMESTAMP YES
 )
 FetchContent_MakeAvailable(json)


### PR DESCRIPTION
DOWNLOAD_EXTRACT_TIMESTAMP is only available with a min version of 3.24, but the recommendation is to set it to a false value which is the default anyway. Dropping it lets older cmake versions build the cpp project.