### PR TITLE
address clang-format security warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _deps
 *.workspace
 discord_bot.json
 /zerotier
+/.cache

--- a/main.cpp
+++ b/main.cpp
@@ -233,21 +233,21 @@ std::string makeVersionString(const GameData& gameData)
 
     std::to_chars_result result = std::to_chars(buffer.data(), end, gameData.versionMajor);
     if(result.ec != std::errc()) {
-        fprintf(stderr, std::make_error_code(result.ec).message().c_str());
+        fprintf(stderr, "%s", std::make_error_code(result.ec).message().c_str());
         return {};
     }
     *result.ptr = '.';
     ++result.ptr;
     result = std::to_chars(result.ptr, end, gameData.versionMinor);
     if(result.ec != std::errc()) {
-        fprintf(stderr, std::make_error_code(result.ec).message().c_str());
+        fprintf(stderr, "%s", std::make_error_code(result.ec).message().c_str());
         return {};
     }
     *result.ptr = '.';
     ++result.ptr;
     result = std::to_chars(result.ptr, end, gameData.versionPatch);
     if(result.ec != std::errc()) {
-        fprintf(stderr, std::make_error_code(result.ec).message().c_str());
+        fprintf(stderr, "%s", std::make_error_code(result.ec).message().c_str());
         return {};
     }
 
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
     for(const auto& game : gameList) {
         root.push_back(game.second);
     }
-    printf(root.dump().c_str());
+    printf("%s", root.dump().c_str());
 
     return 0;
 }


### PR DESCRIPTION
vscode's nice clang-format integration makes these warnings much more visible than on windows, which is a bit of a curse :D

ignoring the cache folder as well so I don't accidentally commit temporary files