### PR TITLE
bump dependencies to work with recent cmake releases

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BUILD_HOST_SELFTEST OFF)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG 47e38259e9c99ba2d8e7241515fa1b56cb538c8c)
+  GIT_TAG 72a518bcf7d87e32f718ca612ce2c8303ceedd12)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 if(NOT ANDROID)

--- a/3rdParty/nlohmann_json/CMakeLists.txt
+++ b/3rdParty/nlohmann_json/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(FetchContent)
 
 FetchContent_Declare(json
-	URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
-	URL_HASH SHA256=8c4b26bf4b422252e13f332bc5e388ec0ab5c3443d24399acb675e68278d341f
+	URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+	URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
 )
 FetchContent_MakeAvailable(json)


### PR DESCRIPTION
our libzt fork declared a pre-3.5 version of cmake which causes the build to fail with newer cmakes. It'd already been bumped on the devx-1.4.0 branch so used the latest hash there.

similar story with nlohmann/json, the latest release includes a minimum version declaration of 3.5 for compatibility with recent cmakes that deprecate older versions.