### PR TITLE
Refactor bot to use an async background task instead of direct call in on_ready handler

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -269,6 +269,8 @@ class GamebotClient(discord.Client):
                     await self.change_presence(activity=activity)
                 except discord.DiscordException as discord_error:
                     logger.warning(repr(discord_error))
+                except Exception as e:
+                    logger.error(e)
 
             logger.debug('Connection lost, waiting for reconnect')
             await self.wait_until_ready()
@@ -293,7 +295,7 @@ def run(runtimeConfig: Dict[str, Any]) -> None:
 
 
 def main() -> None:
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
     handler = logging.StreamHandler()
     formatter = logging.Formatter('[{asctime}] [{levelname:<8}] {name}: {message}', '%Y-%m-%d %H:%M:%S', style='{')
     handler.setFormatter(formatter)

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -228,6 +228,7 @@ class GamebotClient(discord.Client):
 
                     logger.info('Refreshing game list - ' + str(len(games)) + ' games')
 
+                    now = time.time()
                     for game in games:
                         if any_player_name_is_invalid(game['players']) or any_player_name_contains_a_banned_word(game['players']):
                             continue
@@ -237,11 +238,11 @@ class GamebotClient(discord.Client):
                             known_games[key]['players'] = game['players']
                         else:
                             known_games[key] = game
-                            known_games[key]['first_seen'] = time.time()
+                            known_games[key]['first_seen'] = now
 
-                        known_games[key]['last_seen'] = time.time()
+                        known_games[key]['last_seen'] = now
 
-                    ended_games = [key for key, game in known_games.items() if time.time() - game['last_seen'] >= config['game_ttl']]
+                    ended_games = [key for key, game in known_games.items() if now - game['last_seen'] >= config['game_ttl']]
 
                     for key in ended_games:
                         if active_messages:

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -161,7 +161,7 @@ def any_player_name_contains_a_banned_word(players: List[str]) -> bool:
 
 
 class GamebotClient(discord.Client):
-    def __init__(self, *, intents, **options):
+    def __init__(self, *, intents: discord.Intents, **options: dict[str, Any]) -> None:
         intents.message_content = True
         super().__init__(intents=intents, **options)
 
@@ -179,7 +179,7 @@ class GamebotClient(discord.Client):
         assert isinstance(self._channel, discord.TextChannel)
         return await self._channel.send(text)
 
-    async def _background_task(self):
+    async def _background_task(self) -> None:
         await self.wait_until_ready()
 
         logger.debug('Connection established for the first time, preparing for loop start.')
@@ -261,12 +261,12 @@ class GamebotClient(discord.Client):
                         message_text = format_game_message(game)
                         if message_index < len(active_messages):
                             try:
-                                message = await self._update_message(active_messages[message_index], message_text)
+                                maybeMessage = await self._update_message(active_messages[message_index], message_text)
                             except ClientConnectorDNSError as e:
                                 logger.warning('DNS failure when attempting to update an active game message, assuming this is temporary and retrying next iteration.')
                                 continue
-                            assert message is not None
-                            active_messages[message_index] = message
+                            assert maybeMessage is not None
+                            active_messages[message_index] = maybeMessage
                         else:
                             message = await self._send_message(message_text)
                             assert message is not None
@@ -300,11 +300,11 @@ class GamebotClient(discord.Client):
         self.bg_task = self.loop.create_task(self._background_task())
 
 
-    async def on_ready(self):
+    async def on_ready(self) -> None:
         logger.info(f'We have logged in as {self.user}')
 
 
-def _translate_to_log_level(targetLevel: str) -> Optional[str]:
+def _translate_to_log_level(targetLevel: str) -> Optional[int]:
     if targetLevel.lower() == 'trace':
         logger.warning('TRACE is not a supported log level by python\'s logging framework, using DEBUG instead')
         targetLevel = 'debug'
@@ -324,7 +324,7 @@ def _translate_to_log_level(targetLevel: str) -> Optional[str]:
     return None
 
 
-def set_log_level(targetLevel: str):
+def set_log_level(targetLevel: str) -> None:
     loggerLevel = _translate_to_log_level(targetLevel)
 
     if loggerLevel:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord>=2.*
+discord>=2.0


### PR DESCRIPTION
I'm not certain the nested loop approach is appropriate (especially with the catch-all exception handler), this was an experiment to try address a failure case I observed where the background task appeared to exit the main loop due to `client.is_closed()` returning true but the bot appeared to eventually reconnect and call the `on_ready` handler.

The error handling can definitely be improved for each method that potentially fails, opening as a draft in the hopes someone else can run an instance and see what exceptions make it to the catch-all handler.