### PR TITLE
Keep the bot connected to ZT

### DIFF
--- a/run_bot.sh
+++ b/run_bot.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+trap ':' SIGINT
+
+rm -f gamelist.json
+python3 discord_bot.py &
+./devilutionx-gamelist &
+
+while ! wait
+do
+  kill -TERM $(jobs -p)
+done


### PR DESCRIPTION
* `main.cpp`
  * Runs indefinitely, staying connected to the ZeroTier network
  * Sends the game info request once per minute
  * Processes game info replies once every 5 seconds
  * Dumps game info data to `gamelist.json` any time that file does not already exist
  * Adjusted logging to make use of stdout, reduce the frequency of messages, use a more consistent format, and provide more relevant information
* `discord_bot.py`
  * Attempts to load data from `gamelist.json` once per second
  * Deletes `gamelist.json` after loading the data
  * Updates messages on Discord if any new games are loaded from `gamelist.json` or if old games are ended
  * Tweaked how the bot handles timestamps to make use of `time.monotonic()` in places where it makes more sense
  * Reduce frequency of log messages to account for the higher polling rate
* `run_bot.sh`
  * Deletes lingering `gamelist.json` data from previous execution
  * Executes both the Discord bot and the ZT bot in the background
  * Terminates both processes using `SIGTERM` after receiving `Ctrl-C` from the keyboard