### PR TITLE
Track info about ZT members' games and implement IP ban

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ _deps
 discord_bot.json
 /zerotier
 /.cache
+/__pycache__
 *.egg-info
 *.pyc

--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(functions/FetchContent_MakeAvailableExcludeFromAll)
 
 set(BUILD_HOST_SELFTEST OFF)
+set(LWIP_FLAGS "-DLWIP_IPV6_FORWARD=1")
 
 include(FetchContent)
 FetchContent_Declare(libzt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(3rdParty/libzt)
 add_subdirectory(3rdParty/nlohmann_json)
 
 list(APPEND python_SRCS
+  bot_db.py
   discord_bot.py
   ztapi_client.py)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 add_subdirectory(3rdParty/libzt)
 add_subdirectory(3rdParty/nlohmann_json)
 
+list(APPEND python_SRCS
+  discord_bot.py
+  ztapi_client.py)
+
 add_executable(devilutionx-gamelist
   main.cpp
 )
@@ -22,6 +26,10 @@ else()
 endif()
 
 target_link_libraries(devilutionx-gamelist PRIVATE nlohmann_json::nlohmann_json)
+
+foreach(src ${python_SRCS})
+  file(CREATE_LINK "${CMAKE_CURRENT_SOURCE_DIR}/${src}" "${CMAKE_CURRENT_BINARY_DIR}/${src}" SYMBOLIC)
+endforeach()
 
 install(TARGETS devilutionx-gamelist
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/bot_db.py
+++ b/bot_db.py
@@ -1,0 +1,327 @@
+import aiosqlite
+from ipaddress import IPv6Address
+from datetime import date, datetime, timedelta, UTC
+from typing import Any, List, Self
+
+def adapt_datetime_iso(val: datetime) -> str:
+    """Adapt datetime.datetime to timezone-naive ISO 8601 date."""
+    return val.replace(tzinfo=None).isoformat(sep=' ', timespec='seconds')
+
+aiosqlite.register_adapter(datetime, adapt_datetime_iso)
+
+table_definitions = [
+"""\
+CREATE TABLE IF NOT EXISTS MemberSighting
+(
+    ZeroTierMemberID TEXT,
+    PlayerName TEXT,
+    Timestamp DATETIME
+)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_MemberSighting_Search
+ON MemberSighting(PlayerName COLLATE NOCASE, Timestamp DESC)
+""",
+"""\
+CREATE TABLE IF NOT EXISTS PlayerSighting
+(
+    PlayerName TEXT,
+    GameName TEXT,
+    First DATETIME,
+    Last DATETIME
+)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_PlayerSighting_SearchFirst
+ON PlayerSighting(PlayerName COLLATE NOCASE, First DESC)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_PlayerSighting_SearchLast
+ON PlayerSighting(PlayerName COLLATE NOCASE, Last DESC)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_PlayerSighting_GameSearchFirst
+ON PlayerSighting(GameName COLLATE NOCASE, First DESC)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_PlayerSighting_GameSearchLast
+ON PlayerSighting(GameName COLLATE NOCASE, Last DESC)
+""",
+"""\
+CREATE TABLE IF NOT EXISTS ZeroTierMember
+(
+    ID TEXT PRIMARY KEY,
+    PhysicalAddress TEXT,
+    LastSeen DATETIME,
+    Status TEXT
+)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_ZeroTierMember_PhysicalAddress
+ON ZeroTierMember(PhysicalAddress)
+""",
+"""\
+CREATE INDEX IF NOT EXISTS IX_ZeroTierMember_LastSeen
+ON ZeroTierMember(LastSeen DESC)
+""",
+"""\
+CREATE TABLE IF NOT EXISTS IPBan
+(
+    IPAddress TEXT PRIMARY KEY,
+    Expiration DATETIME
+)
+"""
+]
+
+class BotDatabase:
+    def __init__(self, dbPath: str = './bot_data.db') -> None:
+        self._dbPath = dbPath
+
+    async def find_player_by_name(self, name: str) -> List[str]:
+        query = '\n'.join((
+            "SELECT Timestamp, GameName, ZeroTierMemberID",
+            "FROM",
+            "(",
+            "    SELECT Timestamp, PlayerName, NULL GameName, ZeroTierMemberID",
+            "    FROM MemberSighting",
+            "    UNION",
+            "    SELECT First Timestamp, PlayerName, GameName, NULL ZeroTierMemberID",
+            "    FROM PlayerSighting",
+            "    UNION",
+            "    SELECT Last Timestamp, PlayerName, GameName, NULL ZeroTierMemberID",
+            "    FROM PlayerSighting",
+            ") Sighting",
+            "WHERE PlayerName = ? COLLATE NOCASE",
+            "ORDER BY Timestamp DESC",
+            "LIMIT 50",
+        ))
+
+        sightings = []
+        async with self._db.execute(query, (name,)) as cursor:
+            async for row in cursor:
+                timestamp = row[0]
+                gameName = row[1]
+                ztid = row[2]
+                if gameName: sightings.append(f'[{timestamp}] Player {name} spotted in game {gameName}')
+                if ztid: sightings.append(f'[{timestamp}] Member {ztid} spotted playing {name}')
+        return sightings
+
+    async def find_game_by_name(self, name: str) -> List[str]:
+        query = '\n'.join((
+            "SELECT Timestamp, PlayerName",
+            "FROM",
+            "(",
+            "    SELECT First Timestamp, PlayerName, GameName",
+            "    FROM PlayerSighting",
+            "    UNION",
+            "    SELECT Last Timestamp, PlayerName, GameName",
+            "    FROM PlayerSighting",
+            ") Sighting",
+            "WHERE GameName = ? COLLATE NOCASE",
+            "ORDER BY Timestamp DESC",
+            "LIMIT 50",
+        ))
+
+        sightings = []
+        async with self._db.execute(query, (name,)) as cursor:
+            async for row in cursor:
+                timestamp = row[0]
+                playerName = row[1]
+                sightings.append(f'[{timestamp}] Player {playerName} spotted in game {name}')
+        return sightings
+
+    async def find_zt_member_by_id(self, ztid: str) -> str:
+        query = '\n'.join((
+            "SELECT",
+            "    ID,",
+            "    PhysicalAddress,",
+            "    LastSeen,",
+            "    Status",
+            "FROM ZeroTierMember",
+            "WHERE ID = ?",
+        ))
+
+        async with self._db.execute(query, (ztid,)) as cursor:
+            row = await cursor.fetchone()
+            if not row:
+                return ''
+            id = row[0]
+            ip = row[1]
+            lastSeen = row[2]
+            status = row[3]
+            if ip != '':
+                return f'[{id}] ({status}) {ip}, Seen: {lastSeen}'
+            else:
+                return f'[{id}] ({status}) Seen: {lastSeen}'
+
+    async def list_zt_members(self) -> List[str]:
+        query = '\n'.join((
+            "SELECT",
+            "    ID,",
+            "    PhysicalAddress,",
+            "    LastSeen,",
+            "    Status",
+            "FROM ZeroTierMember",
+            "ORDER BY LastSeen DESC",
+            "LIMIT 50",
+        ))
+
+        members = []
+        async with self._db.execute(query) as cursor:
+            async for row in cursor:
+                id = row[0]
+                ip = row[1]
+                lastSeen = row[2]
+                status = row[3]
+                if ip != '':
+                    members.append(f'[{id}] ({status}) {ip}, Last seen: {lastSeen}')
+                else:
+                    members.append(f'[{id}] ({status}) Last seen: {lastSeen}')
+        return members
+
+    async def find_members_to_block(self) -> List[str]:
+        # Limit query to 15 members to avoid ZeroTier rate limit of 20 requests per second
+        query = '\n'.join((
+            "SELECT ZeroTierMember.ID",
+            "FROM",
+            "    IPBan JOIN",
+            "    ZeroTierMember ON IPBan.IPAddress = ZeroTierMember.PhysicalAddress",
+            "WHERE ZeroTierMember.Status <> 'blocked'",
+            "ORDER BY ZeroTierMember.LastSeen DESC",
+            "LIMIT 15",
+        ))
+
+        memberIds = []
+        async with self._db.execute(query) as cursor:
+            async for row in cursor:
+                memberIds.append(row[0])
+        return memberIds
+
+    async def list_bans(self) -> List[str]:
+        query = '\n'.join((
+            "SELECT",
+            "    IPAddress,",
+            "    Expiration",
+            "FROM IPBan",
+            "ORDER BY Expiration DESC",
+            "LIMIT 50",
+        ))
+
+        bans = []
+        async with self._db.execute(query) as cursor:
+            async for row in cursor:
+                ip = row[0]
+                expiration = row[1]
+                bans.append(f'{ip} expires {expiration}')
+        return bans
+
+    async def save_member_sighting(self, ipv6: IPv6Address, playerName: str, at: datetime) -> None:
+        query = '\n'.join((
+            "INSERT INTO MemberSighting",
+            "SELECT",
+            "    :memberId ZeroTierMemberID,",
+            "    :playerName PlayerName,",
+            "    :at Timestamp",
+            "WHERE NOT EXISTS",
+            "(",
+            "    SELECT *",
+            "    FROM MemberSighting",
+            "    WHERE",
+            "        ZeroTierMemberID = :memberId AND",
+            "        PlayerName = :playerName AND",
+            "        Timestamp = :at",
+            ")",
+        ))
+
+        queryParameters = {
+            'memberId': ipv6.packed[-5:].hex(),
+            'playerName': playerName,
+            'at': at
+        }
+
+        async with self._db.cursor() as cursor:
+            await cursor.execute(query, queryParameters)
+        await self._db.commit()
+
+    async def save_player_sighting(self, playerName: str, gameName: str, at: datetime) -> None:
+        updateQuery = '\n'.join((
+            "UPDATE PlayerSighting",
+            "SET Last = ?",
+            "WHERE",
+            # Only update the most recent sighting
+            "    NOT EXISTS"
+            "    (",
+            "        SELECT *",
+            "        FROM PlayerSighting Next",
+            "        WHERE",
+            "            Last > PlayerSighting.Last AND",
+            "            PlayerName = PlayerSighting.PlayerName AND",
+            "            GameName = PlayerSighting.GameName",
+            "    ) AND",
+            "    PlayerName = ? AND",
+            "    GameName = ?",
+        ))
+
+        async with self._db.cursor() as cursor:
+            await cursor.execute(updateQuery, (at, playerName, gameName))
+            if cursor.rowcount == 0:
+                await cursor.execute("INSERT INTO PlayerSighting VALUES(?, ?, ?, ?)", (playerName, gameName, at, at))
+        await self._db.commit()
+
+    async def save_zt_member(self, id: str, physicalAddress: str, lastSeen: datetime, status: str) -> None:
+        memberThreshold = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30)
+        if lastSeen.replace(tzinfo=None) < memberThreshold:
+            return
+
+        query = '\n'.join((
+            "INSERT INTO ZeroTierMember(ID, PhysicalAddress, LastSeen, Status)",
+            "VALUES(:id, :physicalAddress, :lastSeen, :status)",
+            "ON CONFLICT DO UPDATE SET",
+            "    PhysicalAddress = :physicalAddress," if physicalAddress != '' else '',
+            "    LastSeen = :lastSeen,",
+            "    Status = :status",
+        ))
+
+        queryParameters = {
+            'id': id,
+            'physicalAddress': physicalAddress,
+            'lastSeen': lastSeen,
+            'status': status
+        }
+
+        async with self._db.cursor() as cursor:
+            await cursor.execute(query, queryParameters)
+        await self._db.commit()
+
+    async def ban(self, physicalAddress: str) -> None:
+        expiration = datetime.now(UTC) + timedelta(days=30)
+        async with self._db.cursor() as cursor:
+            await cursor.execute("INSERT OR REPLACE INTO IPBan VALUES(?, ?)", (physicalAddress, expiration))
+        await self._db.commit()
+
+    async def remove_ban(self, physicalAddress: str) -> None:
+        async with self._db.cursor() as cursor:
+            await cursor.execute("DELETE FROM IPBan WHERE IPAddress = ?", (physicalAddress,))
+        await self._db.commit()
+
+    async def clean_up(self) -> None:
+        async with self._db.cursor() as cursor:
+            now = datetime.now(UTC)
+            sightingThreshold = now - timedelta(days=14)
+            memberThreshold = now - timedelta(days=30)
+            await cursor.execute("DELETE FROM MemberSighting WHERE Timestamp < ?", (sightingThreshold,))
+            await cursor.execute("DELETE FROM PlayerSighting WHERE Last < ?", (sightingThreshold,))
+            await cursor.execute("DELETE FROM ZeroTierMember WHERE LastSeen < ?", (memberThreshold,))
+            await cursor.execute("DELETE FROM IPBan WHERE Expiration < ?", (now,))
+        await self._db.commit()
+
+    async def __aenter__(self) -> Self:
+        self._db = await aiosqlite.connect(self._dbPath)
+        async with self._db.cursor() as cursor:
+            for table_definition in table_definitions:
+                await cursor.execute(table_definition)
+        await self._db.commit()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self._db.close()

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -11,7 +11,7 @@ import time
 from bot_db import BotDatabase
 from datetime import datetime, UTC
 from ipaddress import IPv6Address
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, Iterator, List, Optional
 from ztapi_client import ZeroTierApiClient
 
 logger = logging.getLogger(__name__)
@@ -167,6 +167,18 @@ def any_player_name_contains_a_banned_word(players: List[str]) -> bool:
     return False
 
 
+async def apply_ip_bans(network: Any, members: Any, db: BotDatabase, zt: ZeroTierApiClient) -> None:
+    memberLookup = {}
+    for member in members:
+        memberId = member['config']['id']
+        memberLookup[memberId] = member
+
+    memberIds = await db.find_members_to_block()
+    for memberId in memberIds:
+        member = memberLookup[memberId]
+        if member: await zt.tag_member(network, member, 'status', 'blocked')
+
+
 async def dump_games(games: Any, db: BotDatabase) -> None:
     now = datetime.now(UTC)
     for game in games:
@@ -209,6 +221,111 @@ class GamebotClient(discord.Client):
         self._last_game_update: float | None = None
         self._last_zt_update: float | None = None
         self._last_log: float | None = None
+
+
+    async def _register_commands(self, db: BotDatabase, zt: ZeroTierApiClient | None) -> None:
+        tree = discord.app_commands.CommandTree(self)
+
+        def split_message(lines: List[str]) -> Iterator[str]:
+            chunk: List[str] = []
+            count = 0
+            for line in lines:
+                seplen = 0 if len(chunk) == 0 else 1
+                if count + len(line) + seplen > 2000:
+                    yield '\n'.join(chunk)
+                    chunk = []
+                    count = 0
+                chunk.append(line)
+                count += len(line) + seplen
+            if len(chunk) > 0:
+                yield '\n'.join(chunk)
+
+        @tree.command(name='findplayer', description='Finds games a player was seen in.')
+        @discord.app_commands.describe(name='The name of the player.')
+        async def findplayer(interaction: discord.Interaction, name: str) -> None:
+            playerSightings = await db.find_player_by_name(name)
+            if len(playerSightings) == 0:
+                await interaction.response.send_message(content='Player not found', ephemeral=True)
+                return
+
+            for chunk in split_message(playerSightings):
+                r = not interaction.response.is_done()
+                if r: await interaction.response.send_message(content=chunk, ephemeral=True)
+                else: await interaction.followup.send(content=chunk, ephemeral=True)
+
+        @tree.command(name='findztgame', description='Finds players that were seen playing in a game.')
+        @discord.app_commands.describe(name='The name of the game.')
+        async def findztgame(interaction: discord.Interaction, name: str) -> None:
+            playerSightings = await db.find_game_by_name(name)
+            if len(playerSightings) == 0:
+                await interaction.response.send_message(content='Player not found', ephemeral=True)
+                return
+
+            for chunk in split_message(playerSightings):
+                r = not interaction.response.is_done()
+                if r: await interaction.response.send_message(content=chunk, ephemeral=True)
+                else: await interaction.followup.send(content=chunk, ephemeral=True)
+
+        @tree.command(name='findztmember', description='Finds info about a ZeroTier member.')
+        @discord.app_commands.describe(ztmemberid='The ZeroTier Member ID (ztid) of the player.')
+        async def findztmember(interaction: discord.Interaction, ztmemberid: str) -> None:
+            ztMemberInfo = await db.find_zt_member_by_id(ztmemberid)
+            if len(ztMemberInfo) == 0:
+                await interaction.response.send_message(content='Member not found', ephemeral=True)
+                return
+            await interaction.response.send_message(content=ztMemberInfo, ephemeral=True)
+
+        @tree.command(name='listztmembers', description='Lists info about recently seen ZeroTier members.')
+        async def listztmembers(interaction: discord.Interaction) -> None:
+            ztMembers = await db.list_zt_members()
+            if len(ztMembers) == 0:
+                await interaction.response.send_message(content='No members', ephemeral=True)
+                return
+
+            for chunk in split_message(ztMembers):
+                r = not interaction.response.is_done()
+                if r: await interaction.response.send_message(content=chunk, ephemeral=True)
+                else: await interaction.followup.send(content=chunk, ephemeral=True)
+
+        @tree.command(name='listbanned', description='List recently banned IP addresses.')
+        async def listbanned(interaction: discord.Interaction) -> None:
+            bans = await db.list_bans()
+            if len(bans) == 0:
+                await interaction.response.send_message(content='No IP bans', ephemeral=True)
+                return
+
+            for chunk in split_message(bans):
+                r = not interaction.response.is_done()
+                if r: await interaction.response.send_message(content=chunk, ephemeral=True)
+                else: await interaction.followup.send(content=chunk, ephemeral=True)
+
+        @tree.command(name='ztban', description='Bans an IP address from using ZeroTier.')
+        @discord.app_commands.describe(ip='The physical IP address of the user.')
+        async def ztban(interaction: discord.Interaction, ip: str) -> None:
+            await db.ban(ip)
+            await interaction.response.send_message(content=f'IP {ip} banned', ephemeral=True)
+
+        @tree.command(name='revokeztban', description='Revokes a previously banned IP address so it can use ZeroTier.')
+        @discord.app_commands.describe(ip='The physical IP address of the user.')
+        async def revokeztban(interaction: discord.Interaction, ip: str) -> None:
+            await db.remove_ban(ip)
+            await interaction.response.send_message(content=f'Revoked ban on {ip}', ephemeral=True)
+
+        if zt:
+            @tree.command(name='setztstatus', description='Updates the value of the status tag for a ZeroTier member.')
+            @discord.app_commands.describe(memberid='The ZeroTier Member ID (ztid) of the player.')
+            @discord.app_commands.describe(status='The status of their membership.')
+            async def setztstatus(interaction: discord.Interaction, memberid: str, status: str) -> None:
+                if status not in ('allowed', 'blocked'):
+                    await interaction.response.send_message(content='Invalid status: must be "allowed" or "blocked"', ephemeral=True)
+                    return
+                network = await zt.get_network(ztid)
+                member = await zt.get_member(ztid, memberid)
+                await zt.tag_member(network, member, 'status', status)
+                await interaction.response.send_message(content=f'Status of member {memberid} updated to {status}', ephemeral=True)
+
+        await tree.sync()
+
 
     async def _update_message(self, message: discord.Message, text: str) -> Optional[discord.Message]:
         if message.content != text:
@@ -335,6 +452,7 @@ class GamebotClient(discord.Client):
         members = await zt.get_members(ztid)
         if not members: return
         await dump_members(network, members, db)
+        await apply_ip_bans(network, members, db, zt)
 
 
     async def _background_task(self) -> None:
@@ -367,14 +485,18 @@ class GamebotClient(discord.Client):
                 except Exception as e:
                     logger.exception('Unknown exception occurred: ')
 
-        async with BotDatabase() as db:
-            async with ZeroTierApiClient(config['zt_token']) as zt:
-                maybeZt = zt if config['zt_token'] != '' else None
-                while True:
-                    logger.debug('Starting main loop')
-                    await main_loop(db, maybeZt)
-                    logger.debug('Connection lost, waiting for reconnect')
-                    await self.wait_until_ready()
+        try:
+            async with BotDatabase() as db:
+                async with ZeroTierApiClient(config['zt_token']) as zt:
+                    maybeZt = zt if config['zt_token'] != '' else None
+                    await self._register_commands(db, maybeZt)
+                    while True:
+                        logger.debug('Starting main loop')
+                        await main_loop(db, maybeZt)
+                        logger.debug('Connection lost, waiting for reconnect')
+                        await self.wait_until_ready()
+        except Exception as e:
+            logger.exception('Unknown exception occurred: ')
 
 
     async def setup_hook(self) -> None:

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -204,10 +204,13 @@ class GamebotClient(discord.Client):
                     timestamp = time.time()
 
                     games = []
+                    sightings = []
                     try:
-                        # Load the file as a JSON list
+                        # Load the file as a JSON object
                         with open(config['gamelist_file']) as file:
-                            games = json.load(file)
+                            gamelist_data = json.load(file)
+                            games = gamelist_data["games"]
+                            sightings = gamelist_data["player_sightings"]
 
                         # Delete the file when we're done with it
                         pathlib.Path.unlink(config['gamelist_file'])

--- a/main.cpp
+++ b/main.cpp
@@ -4,9 +4,12 @@
 #include <chrono>
 #include <cstdio>
 #include <lwip/mld6.h>
+#include <lwip/prot/ethernet.h>
+#include <lwip/prot/tcp.h>
 #include <lwip/sockets.h>
 #include <lwip/tcpip.h>
 #include <map>
+#include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
@@ -19,8 +22,17 @@
 typedef std::vector<uint8_t> buffer_t;
 typedef std::array<uint8_t, 16> address_t;
 
+struct PlayerIdentity {
+    address_t address;
+    std::string name;
+};
+
 uint64_t net_id = 0xa84ac5c10a7ebb5f;
 int default_port = 6112;
+int fd_udp = -1;
+
+std::mutex player_identities_mutex;
+std::vector<PlayerIdentity> player_identities;
 
 const uint8_t dvl_multicast_addr[16] = {
     // clang-format off
@@ -29,16 +41,173 @@ const uint8_t dvl_multicast_addr[16] = {
     // clang-format on
 };
 
-void zt_ip6setup()
+// ZTS_EVENT_NODE_UP:
+void process_pt_message(const uint8_t* src, const uint8_t* pkt, size_t len)
 {
-    ip6_addr_t mcaddr;
-    memcpy(mcaddr.addr, dvl_multicast_addr, 16);
-    mcaddr.zone = 0;
+    constexpr uint8_t CMD_ACK_PLRINFO = 0x02;
+    constexpr uint8_t CMD_SEND_PLRINFO = 0x35;
+    constexpr size_t TPktCheckOffset = 23;
+    constexpr size_t TPktCmdOffset = 27;
+    constexpr size_t TPktOffsetOffset = 28;
+    constexpr size_t TPktPlayerNameOffset = 35;
+    constexpr size_t TPktPlayerNameLength = 32;
+
+    // Skip packet type and player IDs
+    const uint8_t* tpkt = pkt + 3;
+    const size_t tpktLen = len - 3;
+    if(tpktLen < TPktPlayerNameOffset + TPktPlayerNameLength)
+        return;
+
+    // Sanity checks
+    if(tpkt[TPktCheckOffset + 1] != 'i' || tpkt[TPktCheckOffset] != 'p')
+        return;
+    if(tpkt[TPktCmdOffset] != CMD_ACK_PLRINFO && tpkt[TPktCmdOffset] != CMD_SEND_PLRINFO)
+        return;
+    if(tpkt[TPktOffsetOffset] != 0 || tpkt[TPktOffsetOffset + 1] != 0)
+        return;
+
+    address_t playerAddress;
+    memcpy(playerAddress.data(), src, playerAddress.size());
+    const char* namePtr = reinterpret_cast<const char*>(tpkt + TPktPlayerNameOffset);
+    const size_t nameLen = strnlen(namePtr, TPktPlayerNameLength);
+    std::string playerName(namePtr, nameLen);
+
+    std::lock_guard<std::mutex> lock(player_identities_mutex);
+    player_identities.emplace_back(PlayerIdentity { playerAddress, playerName });
+}
+
+err_t ethernet_input(struct pbuf* p, struct netif* n)
+{
+    fprintf(stderr, "ZeroTier: Ethernet input not supported (netif=%c%c)\n", n->name[0], n->name[1]);
+    return ERR_IF;
+}
+
+err_t ethip6_output(struct netif* n, struct pbuf* p, const ip6_addr_t* ip6addr)
+{
+    // Maximum MTU for ZeroTier virtual networks
+    constexpr size_t ZT_MAX_MTU = 10000;
+    uint8_t buf[ZT_MAX_MTU + 32];
+    size_t len = 0;
+
+    for(struct pbuf* q = p; q != nullptr; q = q->next) {
+        memcpy(buf + len, q->payload, q->len);
+        len += q->len;
+    }
+
+    size_t pos = 40;
+    uint8_t protocol = buf[6];
+    while(pos <= len) {
+        switch(protocol) {
+            case 0: // hop-by-hop options
+            case 43: // routing
+            case 60: // destination options
+            case 135: // mobility options
+                if ((pos + 8) > len)
+                    return ERR_IF; // invalid!
+                protocol = buf[pos];
+                pos += ((unsigned int)buf[pos + 1] * 8) + 8;
+                continue;
+        }
+        break;
+    }
+
+    // Only inspect non-empty TCP packets
+    if(pos >= len || protocol != IPPROTO_TCP)
+        return ERR_OK;
+
+    const uint8_t* tcpData = buf + pos;
+    const size_t tcpLen = len - pos;
+    if(tcpLen < TCP_HLEN) return ERR_OK;
+    const struct tcp_hdr* header = reinterpret_cast<const struct tcp_hdr*>(tcpData);
+
+    // The game client communicates on TCP 6112
+    const uint16_t sourcePort = lwip_ntohs(header->src);
+    const uint16_t destinationPort = lwip_ntohs(header->dest);
+    if(sourcePort != 6112 && destinationPort != 6112)
+        return ERR_OK;
+
+    const size_t headerLen = TCPH_HDRLEN_BYTES(header);
+    if(tcpLen < headerLen) return ERR_OK;
+    const uint8_t* payload = tcpData + headerLen;
+    size_t payloadLen = tcpLen - headerLen;
+
+    while(payloadLen >= sizeof(uint32_t)) {
+        const uint32_t packetSize = *reinterpret_cast<const uint32_t*>(payload);
+        if(packetSize <= 0) break;
+        payload += sizeof(uint32_t);
+        payloadLen -= sizeof(uint32_t);
+        if(payloadLen < packetSize) break;
+
+        constexpr uint8_t PT_MESSAGE = 0x01;
+        const uint8_t packetType = payload[0];
+        if(packetType == PT_MESSAGE)
+            process_pt_message(buf + 8, payload, packetSize);
+        payload += packetSize;
+        payloadLen -= packetSize;
+    }
+
+    return ERR_OK;
+}
+
+err_t zts_lwip_eth_tx(struct netif* n, struct pbuf* p)
+{
+    fprintf(stderr, "ZeroTier: Link output not supported (netif=%c%c)\n", n->name[0], n->name[1]);
+    return ERR_IF;
+}
+
+static err_t netif_init6(struct netif* n)
+{
+    if (n == nullptr) {
+        return ERR_IF;
+    }
+    n->hwaddr[5] = 0xf3;
+    n->hwaddr[4] = 0xaa;
+    n->hwaddr[3] = 0x3d;
+    n->hwaddr[2] = 0xf3;
+    n->hwaddr[1] = 0xb2;
+    n->hwaddr[0] = 0x8e;
+    n->hwaddr_len = 6;
+    n->name[0] = 'd';
+    n->name[1] = 'x';
+    n->linkoutput = zts_lwip_eth_tx;
+    n->output_ip6 = ethip6_output;
+    n->mtu = LWIP_MTU;
+    n->flags = NETIF_FLAG_ETHERNET | NETIF_FLAG_LINK_UP | NETIF_FLAG_UP;
+    return ERR_OK;
+}
+
+void create_network_interface(struct netif* n, ip6_addr_t* ip6)
+{
     LOCK_TCPIP_CORE();
-    mld6_joingroup(IP6_ADDR_ANY6, &mcaddr);
+    netif_add(n, nullptr, nullptr, nullptr, nullptr, netif_init6, ethernet_input);
+    n->ip6_autoconfig_enabled = 1;
+    netif_create_ip6_linklocal_address(n, 1);
+    netif_set_link_up(n);
+    netif_set_up(n);
+    netif_add_ip6_address(n, ip6, nullptr);
     UNLOCK_TCPIP_CORE();
 }
 
+void create_packet_sniffer()
+{
+    static struct netif n;
+    ip6_addr_t ip;
+    IP6_ADDR_PART(&ip, 0,
+        0xfd,
+        (net_id >> 56) & 0xff,
+        (net_id >> 48) & 0xff,
+        (net_id >> 40) & 0xff);
+    IP6_ADDR_PART(&ip, 1,
+        (net_id >> 32) & 0xff,
+        (net_id >> 24) & 0xff,
+        (net_id >> 16) & 0xff,
+        (net_id >> 8) & 0xff);
+    IP6_ADDR_PART(&ip, 2, net_id & 0xff, 0xdb, 0x07, 0x00);
+    IP6_ADDR_PART(&ip, 3, 0x00, 0x00, 0x00, 0x01);
+    create_network_interface(&n, &ip);
+}
+
+// ZTS_EVENT_NODE_ONLINE:
 void set_reuseaddr(int fd)
 {
     const int yes = 1;
@@ -52,8 +221,6 @@ void set_nonblock(int fd)
     mode |= O_NONBLOCK;
     lwip_fcntl(fd, F_SETFL, mode);
 }
-
-int fd_udp = -1;
 
 void bring_network_online()
 {
@@ -76,6 +243,18 @@ void bring_network_online()
     }
 }
 
+// ZTS_EVENT_NETWORK_READY_IP6:
+void zt_ip6setup()
+{
+    ip6_addr_t mcaddr;
+    memcpy(mcaddr.addr, dvl_multicast_addr, 16);
+    mcaddr.zone = 0;
+    LOCK_TCPIP_CORE();
+    mld6_joingroup(IP6_ADDR_ANY6, &mcaddr);
+    UNLOCK_TCPIP_CORE();
+}
+
+// ZTS_EVENT_ADDR_ADDED_IP6:
 void print_ip6_addr(void* x)
 {
     char ipstr[INET6_ADDRSTRLEN];
@@ -99,7 +278,9 @@ const char* zt_event_to_string(int16_t event_code)
     switch(event_code) {
     case ZTS_EVENT_NODE_ONLINE: return "ZTS_EVENT_NODE_OFFLINE";
     case ZTS_EVENT_NODE_OFFLINE: return "ZTS_EVENT_NODE_OFFLINE";
+    case ZTS_EVENT_NETWORK_READY_IP4: return "ZTS_EVENT_NETWORK_READY_IP4";
     case ZTS_EVENT_NETWORK_READY_IP6: return "ZTS_EVENT_NETWORK_READY_IP6";
+    case ZTS_EVENT_ADDR_ADDED_IP4: return "ZTS_EVENT_ADDR_ADDED_IP4";
     case ZTS_EVENT_ADDR_ADDED_IP6: return "ZTS_EVENT_ADDR_ADDED_IP6";
     case ZTS_EVENT_NODE_UP: return "ZTS_EVENT_NODE_UP";
     case ZTS_EVENT_NETWORK_OK: return "ZTS_EVENT_NETWORK_OK";
@@ -151,6 +332,10 @@ static void Callback(void* ptr)
     zts_event_msg_t* msg = reinterpret_cast<zts_event_msg_t*>(ptr);
 
     switch(msg->event_code) {
+    case ZTS_EVENT_NODE_UP:
+        create_packet_sniffer();
+        break;
+
     case ZTS_EVENT_NODE_ONLINE:
         printf("ZeroTier: ZTS_EVENT_NODE_ONLINE, nodeId=%llx\n", (unsigned long long)msg->node->node_id);
         zt_node_online = true;
@@ -272,6 +457,14 @@ bool recv(address_t& addr, buffer_t& data)
     memcpy(data.data(), buf, len);
     std::copy(in6.sin6_addr.s6_addr, in6.sin6_addr.s6_addr + 16, addr.begin());
     return true;
+}
+
+std::vector<PlayerIdentity> get_player_sightings()
+{
+    std::lock_guard<std::mutex> lock(player_identities_mutex);
+    std::vector<PlayerIdentity> playerSightings = player_identities;
+    player_identities.clear();
+    return playerSightings;
 }
 
 constexpr uint8_t MaxPlayers = 4;
@@ -404,6 +597,7 @@ int main(int argc, char* argv[])
 
     std::map<std::string, GameInfo> gameList;
     std::size_t totalReplies = 0;
+    std::size_t totalSightings = 0;
 
     printf("ZeroTier: Sending multicast game info request\n");
     send_oob_mc({ InfoRequest, Broadcast, Host });
@@ -415,6 +609,7 @@ int main(int argc, char* argv[])
         if(diff >= std::chrono::seconds(60)) {
             printf("ZeroTier: Sending multicast game info request\n");
             printf("ZeroTier: Total replies received so far: %zu\n", totalReplies);
+            printf("ZeroTier: Total player sightings so far: %zu\n", totalSightings);
             if(!gameList.empty()) {
                 fprintf(stderr, "ZeroTier: Holding %zu games since last request! Is discord_bot running?\n", gameList.size());
             }
@@ -432,13 +627,32 @@ int main(int argc, char* argv[])
             }
         }
 
-        if(!gameList.empty()) {
+        std::vector<PlayerIdentity> sightingList = get_player_sightings();
+        totalSightings += sightingList.size();
+
+        if(!gameList.empty() || !sightingList.empty()) {
             FILE* gameFile = fopen(gameFilePath, "wbx");
             if(gameFile != nullptr) {
-                nlohmann::json root = nlohmann::json::array();
+                nlohmann::json games = nlohmann::json::array();
                 for(const auto& game : gameList) {
-                    root.push_back(game.second);
+                    games.push_back(game.second);
                 }
+
+                nlohmann::json sightings = nlohmann::json::array();
+                for(const auto& sighting : sightingList) {
+                    char ipstr[INET6_ADDRSTRLEN];
+                    if(lwip_inet_ntop(AF_INET6, sighting.address.data(), ipstr, INET6_ADDRSTRLEN) == NULL)
+                        continue;     // insufficient buffer, shouldn't be possible.
+                    sightings.push_back(nlohmann::json {
+                        { "address", std::string(ipstr) },
+                        { "name", sighting.name }
+                    });
+                }
+
+                nlohmann::json root = nlohmann::json {
+                    { "games", games },
+                    { "player_sightings", sightings }
+                };
 
                 std::string text = root.dump();
                 std::fwrite(text.data(), sizeof(char), text.size(), gameFile);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp>=3.11.16
+aiosqlite>=0.21.0
 discord>=2.0

--- a/ztapi_client.py
+++ b/ztapi_client.py
@@ -1,0 +1,62 @@
+import aiohttp
+import logging
+from typing import Any, Self
+
+logger = logging.getLogger(__name__)
+
+class ZeroTierApiClient:
+    def __init__(self, token: str) -> None:
+        self._baseUrl = 'https://api.zerotier.com/api/v1'
+        self._session = aiohttp.ClientSession(headers={'Authorization': f'token {token}'})
+
+    async def get_network(self, networkId: str) -> Any:
+        url = f'{self._baseUrl}/network/{networkId}'
+        async with self._session.get(url) as response:
+            if response.status == 200:
+                return await response.json()
+            self._log_error(response.status, 'Failed to retrieve ZeroTier network')
+            return None
+
+    async def get_members(self, networkId: str) -> Any:
+        url = f'{self._baseUrl}/network/{networkId}/member'
+        async with self._session.get(url) as response:
+            if response.status == 200:
+                return await response.json()
+            self._log_error(response.status, 'Failed to retrieve ZeroTier member list')
+            return None
+
+    async def get_member(self, networkId: str, memberId: str) -> Any:
+        url = f'{self._baseUrl}/network/{networkId}/member/{memberId}'
+        async with self._session.get(url) as response:
+            if response.status == 200:
+                return await response.json()
+            self._log_error(response.status, 'Failed to retrieve ZeroTier member')
+            return None
+
+    async def tag_member(self, network: Any, member: Any, tag: str, tagValue: str) -> None:
+        tagId = network['tagsByName'][tag]['id']
+        tagValueId = network['tagsByName'][tag]['enums'][tagValue]
+        tags = [tag for tag in member['config']['tags'] if tag[0] != tagId]
+        tags.append([tagId, tagValueId])
+
+        networkId = network['id']
+        memberId = member['config']['id']
+        url = f'{self._baseUrl}/network/{networkId}/member/{memberId}'
+        payload = {'config': {'tags': tags}}
+        async with self._session.post(url, json=payload) as response:
+            if response.status == 200: return
+            self._log_error(response.status, 'Failed to update ZeroTier member tag')
+
+    def _log_error(self, status: int, message: str) -> None:
+        message += f': {status}'
+        match status:
+            case 401: message += ' Authorization required'
+            case 403: message += ' Access denied'
+            case 404: message += ' Item not found'
+        logger.error(message)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self._session.close()


### PR DESCRIPTION
Here we have an actually working version of a bot that can ban players from ZeroTier. Now that the bot can stay connected to ZeroTier, it is possible to receive messages pushed from the game client in addition to messages we request via `PT_INFO_REQUEST`.

As it turns out, it's possible to configure flow rules in ZeroTier Central to specify that packets on the network should be copied and sent to a specific member. So I came up with a rule definition that can send all communications over TCP 6112 to the bot.

```
tee -1 <botMemberId>
  sport 6112
  or dport 6112
  and ipprotocol tcp
;
```

The next thing I needed to do was implement a packet sniffer on the bot so I could read `CMD_ACK_PLRINFO` and `CMD_SEND_PLRINFO` packets. The IPv6 header provides the ZT IP address of the player who sent the message, and the TCP payload provides the name of the player. This solves the problem I was unable to solve in #42 where we couldn't get enough information to actually execute a ban if players only ever joined games. With this approach, any time a player joins another player's game, we get the addresses and names of all the players in said game, as they exchange that info with one another.

To implement the packet sniffer, I needed a workaround for LWIP because their IPv6 routing logic rejects packets on a network interface that are not destined to the interface's IP address--an exact IP address match! Instead of adding every possible IPv6 address to ZT's network interface, I enabled IPv6 forwarding with `-DLWIP_IPV6_FORWARD=1` and created my own network interface that LWIP could forward the packets to. To have the packets forwarded, I only needed to generate an IPv6 address that matches the first 64 bits of any ZT IPv6 address and then add the interface via `netif_add()` _after_ ZT adds its network interface. This last part explains why the packet sniffer is added in the `ZTS_EVENT_NODE_UP` event.

The rest is pretty much the same as the last PR. Info about players, games, and member IDs are all stored in a SQLite database called `bot_data.db`. There is a set of Discord commands that can be used to query information and ban players by IP. These are added as slash commands so we can configure permissions via Discord's server administration and also see command info while typing the commands in the Discord client.

![image](https://github.com/user-attachments/assets/b28b3acc-e4d4-4f34-ac8d-ee0760b15535)

Replaces #42 and #34
Depends on #44