### PR TITLE
add aiohttp to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+aiohttp>=3.11.16
 discord>=2.0


### PR DESCRIPTION
While this is an implied dependency via discord.py and we only use it to handle exceptions thrown by that module, pylance still reports a warning for importing from a dependency we don't declare ourselves.

obsoleted by #45 as staphen adds aiohttp as a direct dependency in the ztapi_client module, only opening this in case you want to take more time to review that PR before merging.