### PR TITLE
Include new modules in pyproject.toml, add python workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,30 @@
+name: Python tool distributions
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Build distributions
+      run: pipx run build
+
+    - name: Upload
+      if: ${{ !env.ACT }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: discord_bot
+        path: dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 /build*
+/dist
 /out
 .vs
 *.project

--- a/README.md
+++ b/README.md
@@ -5,7 +5,24 @@
 Small program for printing out a json list of current games
 
 ## How to build
-```
+```sh
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 ```
+
+Premade binaries are available from the [linux](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/linux.yml?query=branch%3Amain) and [windows](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/windows.yml?query=branch%3Amain) workflows.
+
+# discord_bot.py
+Companion utility that watches for the output of devilutionx-gamelist and advertises the games in a discord channel
+
+## How to build/run
+```sh
+# optionally create/activate a venv-like isolated environment
+pip install -r requirements.txt # or install dependencies at a user level if not using a venv, or via your system package manager
+python discord_bot.py
+# OR
+pip install -e . # could also use pipx or similar tools
+discord_bot
+```
+
+Source and wheel distributions are available from the [python](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/python.yml?query=branch%3Amain) workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.8"
 dependencies = { file = "requirements.txt" }
 
 [tool.setuptools]
-py-modules = ["discord_bot"]
+py-modules = ["discord_bot", "bot_db", "ztapi_client"]
 
 [project.scripts]
 discord_bot = "discord_bot:main"


### PR DESCRIPTION
This fixes the pyproject.toml module declaration to include the extra modules created in #44 (only really required because we're not using a structure that supports auto-discovery however changing that would be annoying).

With only that change it'd actually be possible to use a system-wide install of pipx to run the python component standalone using `pipx run --spec git+https://github.com/diasurgical/devilutionx-gamelist.git discord_bot`, the python action is mainly just to align with the cpp component.