### PR TITLE
Add mypy check badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Linux](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/linux.yml/badge.svg)](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/linux.yml)
 [![Windows](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/windows.yml/badge.svg)](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/windows.yml)
+[![MyPy Check](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/mypy.yml/badge.svg)](https://github.com/diasurgical/devilutionx-gamelist/actions/workflows/mypy.yml)
 
 # devilutionx-gamelist
 Small program for printing out a json list of current games


### PR DESCRIPTION
not bothering with the python workflow as it doesn't actually perform any validation beyond having a valid pyproject.toml (e.g. there could be missing dependencies or it produces an incomplete distribution while the build still shows green).