### PR TITLE
Fix mypy type annotation for kwargs parameter

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -229,7 +229,7 @@ async def dump_members(network: Any, members: Any, db: BotDatabase) -> None:
 
 
 class GamebotClient(discord.Client):
-    def __init__(self, *, intents: discord.Intents, **options: dict[str, Any]) -> None:
+    def __init__(self, *, intents: discord.Intents, **options: Any) -> None:
         intents.message_content = True
         super().__init__(intents=intents, **options)
         self._last_game_update: float | None = None


### PR DESCRIPTION
## Summary
- Fix incorrect type annotation for `**options` parameter in `GamebotClient.__init__`
- Change `**options: dict[str, Any]` to `**options: Any` since kwargs annotations specify the value type, not the full dict type

## Test plan
- [x] Run `mypy` on all Python files - passes

Reference: https://typing.python.org/en/latest/spec/callables.html#annotating-args-and-kwargs