### PR TITLE
Add pytest test suite and CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,26 @@
+name: Pytest
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt pytest pytest-asyncio pytest-aiohttp
+
+    - name: Run tests
+      run: pytest tests/ -v

--- a/tests/test_bot_db.py
+++ b/tests/test_bot_db.py
@@ -1,0 +1,170 @@
+import pathlib
+import pytest
+import pytest_asyncio
+from collections.abc import AsyncGenerator
+from datetime import datetime, timedelta, UTC
+from ipaddress import IPv6Address
+from bot_db import BotDatabase, adapt_datetime_iso
+
+
+class TestAdaptDatetimeIso:
+    def test_converts_datetime_to_iso_string(self) -> None:
+        dt = datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC)
+        result = adapt_datetime_iso(dt)
+        assert result == "2024-01-15 10:30:45"
+
+    def test_strips_timezone_info(self) -> None:
+        dt = datetime(2024, 6, 20, 14, 0, 0, tzinfo=UTC)
+        result = adapt_datetime_iso(dt)
+        assert "+" not in result
+        assert "Z" not in result
+
+
+class TestBotDatabase:
+    @pytest_asyncio.fixture
+    async def db(self, tmp_path: pathlib.Path) -> AsyncGenerator[BotDatabase, None]:
+        db_path = str(tmp_path / "test.db")
+        async with BotDatabase(db_path) as db:
+            yield db
+
+    @pytest.mark.asyncio
+    async def test_save_and_find_player_by_name(self, db: BotDatabase) -> None:
+        ipv6 = IPv6Address("fd00::abcd:1234:5678")
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_member_sighting(ipv6, "TestPlayer", now)
+
+        results = await db.find_player_by_name("TestPlayer")
+        assert len(results) == 1
+        assert "TestPlayer" in results[0]
+
+    @pytest.mark.asyncio
+    async def test_find_player_case_insensitive(self, db: BotDatabase) -> None:
+        ipv6 = IPv6Address("fd00::abcd:1234:5678")
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_member_sighting(ipv6, "TestPlayer", now)
+
+        results = await db.find_player_by_name("testplayer")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_find_player_not_found(self, db: BotDatabase) -> None:
+        results = await db.find_player_by_name("NonExistent")
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_save_and_find_game_by_name(self, db: BotDatabase) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_player_sighting("PlayerOne", "TestGame", now)
+
+        results = await db.find_game_by_name("TestGame")
+        assert len(results) == 1
+        assert "PlayerOne" in results[0]
+
+    @pytest.mark.asyncio
+    async def test_player_sighting_updates_last_time(self, db: BotDatabase) -> None:
+        first = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_player_sighting("Player", "Game", first)
+
+        second = first + timedelta(minutes=5)
+        await db.save_player_sighting("Player", "Game", second)
+
+        results = await db.find_game_by_name("Game")
+        # Should have 2 results (first and last timestamps)
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_save_and_find_zt_member(self, db: BotDatabase) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_zt_member("abc123", "192.168.1.1", now, "allowed")
+
+        result = await db.find_zt_member_by_id("abc123")
+        assert "abc123" in result
+        assert "192.168.1.1" in result
+        assert "allowed" in result
+
+    @pytest.mark.asyncio
+    async def test_find_zt_member_not_found(self, db: BotDatabase) -> None:
+        result = await db.find_zt_member_by_id("nonexistent")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_zt_member_without_ip(self, db: BotDatabase) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_zt_member("abc123", "", now, "allowed")
+
+        result = await db.find_zt_member_by_id("abc123")
+        assert "abc123" in result
+        assert "192.168" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_zt_members(self, db: BotDatabase) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_zt_member("member1", "10.0.0.1", now, "allowed")
+        await db.save_zt_member("member2", "10.0.0.2", now, "blocked")
+
+        members = await db.list_zt_members()
+        assert len(members) == 2
+
+    @pytest.mark.asyncio
+    async def test_old_zt_member_not_saved(self, db: BotDatabase) -> None:
+        old_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=31)
+        await db.save_zt_member("oldmember", "10.0.0.1", old_date, "allowed")
+
+        result = await db.find_zt_member_by_id("oldmember")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_ban_and_list_bans(self, db: BotDatabase) -> None:
+        await db.ban("192.168.1.100")
+
+        bans = await db.list_bans()
+        assert len(bans) == 1
+        assert "192.168.1.100" in bans[0]
+
+    @pytest.mark.asyncio
+    async def test_remove_ban(self, db: BotDatabase) -> None:
+        await db.ban("192.168.1.100")
+        await db.remove_ban("192.168.1.100")
+
+        bans = await db.list_bans()
+        assert len(bans) == 0
+
+    @pytest.mark.asyncio
+    async def test_find_members_to_block(self, db: BotDatabase) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_zt_member("member1", "192.168.1.100", now, "allowed")
+        await db.ban("192.168.1.100")
+
+        to_block = await db.find_members_to_block()
+        assert "member1" in to_block
+
+    @pytest.mark.asyncio
+    async def test_already_blocked_not_in_find_members_to_block(self, db: BotDatabase) -> None:
+        now = datetime.now(UTC).replace(tzinfo=None)
+        await db.save_zt_member("member1", "192.168.1.100", now, "blocked")
+        await db.ban("192.168.1.100")
+
+        to_block = await db.find_members_to_block()
+        assert "member1" not in to_block
+
+    @pytest.mark.asyncio
+    async def test_clean_up_removes_old_sightings(self, db: BotDatabase) -> None:
+        old = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=15)
+        ipv6 = IPv6Address("fd00::abcd:1234:5678")
+        await db.save_member_sighting(ipv6, "OldPlayer", old)
+
+        await db.clean_up()
+
+        results = await db.find_player_by_name("OldPlayer")
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_clean_up_keeps_recent_sightings(self, db: BotDatabase) -> None:
+        recent = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+        ipv6 = IPv6Address("fd00::abcd:1234:5678")
+        await db.save_member_sighting(ipv6, "RecentPlayer", recent)
+
+        await db.clean_up()
+
+        results = await db.find_player_by_name("RecentPlayer")
+        assert len(results) == 1

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,0 +1,325 @@
+import pathlib
+import pytest
+from discord_bot import (
+    escape_discord_formatting_characters,
+    format_game_message,
+    format_status_message,
+    format_time_delta,
+    any_player_name_is_invalid,
+    any_player_name_contains_a_banned_word,
+    config,
+)
+
+
+class TestEscapeDiscordFormattingCharacters:
+    def test_escapes_asterisks(self) -> None:
+        assert escape_discord_formatting_characters("*bold*") == "\\*bold\\*"
+
+    def test_escapes_underscores(self) -> None:
+        assert escape_discord_formatting_characters("_italic_") == "\\_italic\\_"
+
+    def test_escapes_tildes(self) -> None:
+        assert escape_discord_formatting_characters("~strike~") == "\\~strike\\~"
+
+    def test_escapes_backticks(self) -> None:
+        assert escape_discord_formatting_characters("`code`") == "\\`code\\`"
+
+    def test_escapes_pipes(self) -> None:
+        assert escape_discord_formatting_characters("||spoiler||") == "\\|\\|spoiler\\|\\|"
+
+    def test_escapes_multiple_characters(self) -> None:
+        result = escape_discord_formatting_characters("*_~`|#@")
+        assert result == "\\*\\_\\~\\`\\|\\#\\@"
+
+    def test_plain_text_unchanged(self) -> None:
+        assert escape_discord_formatting_characters("hello world") == "hello world"
+
+
+class TestFormatTimeDelta:
+    def test_one_minute(self) -> None:
+        assert format_time_delta(1) == "1 minute"
+
+    def test_few_minutes(self) -> None:
+        assert format_time_delta(5) == "5 minutes"
+
+    def test_59_minutes(self) -> None:
+        assert format_time_delta(59) == "59 minutes"
+
+    def test_one_hour(self) -> None:
+        assert format_time_delta(60) == "1 hour"
+
+    def test_one_hour_and_minutes(self) -> None:
+        assert format_time_delta(75) == "1 hour and 15 minutes"
+
+    def test_two_hours(self) -> None:
+        assert format_time_delta(120) == "2 hours"
+
+    def test_multiple_hours_and_minutes(self) -> None:
+        assert format_time_delta(150) == "2 hours and 30 minutes"
+
+
+class TestFormatStatusMessage:
+    def test_singular_game(self) -> None:
+        result = format_status_message(1)
+        assert result == "There is currently **1** public game."
+
+    def test_plural_games(self) -> None:
+        result = format_status_message(5)
+        assert result == "There are currently **5** public games."
+
+    def test_zero_games(self) -> None:
+        result = format_status_message(0)
+        assert result == "There are currently **0** public games."
+
+
+class TestFormatGameMessage:
+    def test_basic_game(self) -> None:
+        game = {
+            "id": "testgame",
+            "type": "DRTL",
+            "version": "1.5.0",
+            "tick_rate": 20,
+            "difficulty": 0,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "**TESTGAME**" in result
+        assert "Normal" in result
+        assert "Player1" in result
+
+    def test_ended_game_strikethrough(self) -> None:
+        game = {
+            "id": "testgame",
+            "type": "DRTL",
+            "version": "1.5.0",
+            "tick_rate": 20,
+            "difficulty": 0,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+            "ended": 1700003600,
+            "first_seen": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "~~TESTGAME~~" in result
+        assert "Ended after:" in result
+
+    def test_hellfire_game(self) -> None:
+        game = {
+            "id": "hfgame",
+            "type": "HRTL",
+            "version": "1.5.0",
+            "tick_rate": 20,
+            "difficulty": 1,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "hellfire" in result
+        assert "Nightmare" in result
+
+    def test_hell_difficulty(self) -> None:
+        game = {
+            "id": "hellgame",
+            "type": "DRTL",
+            "version": "1.5.0",
+            "tick_rate": 20,
+            "difficulty": 2,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "Hell" in result
+
+    def test_game_with_attributes(self) -> None:
+        game = {
+            "id": "attrsgame",
+            "type": "HRTL",
+            "version": "1.5.0",
+            "tick_rate": 20,
+            "difficulty": 0,
+            "run_in_town": True,
+            "full_quests": True,
+            "theo_quest": True,
+            "cow_quest": True,
+            "friendly_fire": True,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "Run in Town" in result
+        assert "Quests" in result
+        assert "Theo Quest" in result
+        assert "Cow Quest" in result
+        assert "Friendly Fire" in result
+
+    def test_tick_rate_fast_pre_160(self) -> None:
+        game = {
+            "id": "fastgame",
+            "type": "DRTL",
+            "version": "1.5.0",
+            "tick_rate": 30,
+            "difficulty": 0,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "Fast" in result
+
+    def test_tick_rate_fast_post_160(self) -> None:
+        game = {
+            "id": "fastgame",
+            "type": "DRTL",
+            "version": "1.6.0",
+            "tick_rate": 25,
+            "difficulty": 0,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Player1"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "Fast" in result
+
+    def test_multiple_players(self) -> None:
+        game = {
+            "id": "multigame",
+            "type": "DRTL",
+            "version": "1.5.0",
+            "tick_rate": 20,
+            "difficulty": 0,
+            "run_in_town": False,
+            "full_quests": False,
+            "theo_quest": False,
+            "cow_quest": False,
+            "friendly_fire": False,
+            "players": ["Alice", "Bob", "Charlie"],
+            "timestamp": 1700000000,
+        }
+        result = format_game_message(game)
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "Charlie" in result
+
+
+class TestAnyPlayerNameIsInvalid:
+    def test_valid_names(self) -> None:
+        assert any_player_name_is_invalid(["Alice", "Bob123"]) is False
+
+    def test_name_with_comma(self) -> None:
+        assert any_player_name_is_invalid(["Ali,ce"]) is True
+
+    def test_name_with_space(self) -> None:
+        assert any_player_name_is_invalid(["Ali ce"]) is True
+
+    def test_name_with_angle_brackets(self) -> None:
+        assert any_player_name_is_invalid(["<script>"]) is True
+
+    def test_name_with_percent(self) -> None:
+        assert any_player_name_is_invalid(["100%"]) is True
+
+    def test_name_with_ampersand(self) -> None:
+        assert any_player_name_is_invalid(["Tom&Jerry"]) is True
+
+    def test_name_with_backslash(self) -> None:
+        assert any_player_name_is_invalid(["path\\name"]) is True
+
+    def test_name_with_quotes(self) -> None:
+        assert any_player_name_is_invalid(['say"hi"']) is True
+
+    def test_name_with_question_mark(self) -> None:
+        assert any_player_name_is_invalid(["who?"]) is True
+
+    def test_name_with_asterisk(self) -> None:
+        assert any_player_name_is_invalid(["star*"]) is True
+
+    def test_name_with_hash(self) -> None:
+        assert any_player_name_is_invalid(["hash#tag"]) is True
+
+    def test_name_with_slash(self) -> None:
+        assert any_player_name_is_invalid(["path/name"]) is True
+
+    def test_name_with_colon(self) -> None:
+        assert any_player_name_is_invalid(["time:now"]) is True
+
+    def test_name_with_control_character(self) -> None:
+        assert any_player_name_is_invalid(["test\x00"]) is True
+
+    def test_name_with_non_ascii(self) -> None:
+        assert any_player_name_is_invalid(["tëst"]) is True
+
+    def test_mixed_valid_invalid(self) -> None:
+        assert any_player_name_is_invalid(["ValidName", "Invalid Name"]) is True
+
+
+class TestAnyPlayerNameContainsBannedWord:
+    def test_no_banlist_file(self, tmp_path: pathlib.Path) -> None:
+        original = config["banlist_file"]
+        config["banlist_file"] = str(tmp_path / "nonexistent")
+        result = any_player_name_contains_a_banned_word(["Player"])
+        config["banlist_file"] = original
+        assert result is False
+
+    def test_empty_banlist(self, tmp_path: pathlib.Path) -> None:
+        banlist = tmp_path / "banlist"
+        banlist.write_text("")
+        original = config["banlist_file"]
+        config["banlist_file"] = str(banlist)
+        result = any_player_name_contains_a_banned_word(["Player"])
+        config["banlist_file"] = original
+        assert result is False
+
+    def test_banned_word_found(self, tmp_path: pathlib.Path) -> None:
+        banlist = tmp_path / "banlist"
+        banlist.write_text("badword\n")
+        original = config["banlist_file"]
+        config["banlist_file"] = str(banlist)
+        result = any_player_name_contains_a_banned_word(["xbadwordx"])
+        config["banlist_file"] = original
+        assert result is True
+
+    def test_banned_word_case_insensitive(self, tmp_path: pathlib.Path) -> None:
+        banlist = tmp_path / "banlist"
+        banlist.write_text("BADWORD\n")
+        original = config["banlist_file"]
+        config["banlist_file"] = str(banlist)
+        result = any_player_name_contains_a_banned_word(["badword"])
+        config["banlist_file"] = original
+        assert result is True
+
+    def test_no_banned_word(self, tmp_path: pathlib.Path) -> None:
+        banlist = tmp_path / "banlist"
+        banlist.write_text("badword\n")
+        original = config["banlist_file"]
+        config["banlist_file"] = str(banlist)
+        result = any_player_name_contains_a_banned_word(["goodplayer"])
+        config["banlist_file"] = original
+        assert result is False

--- a/tests/test_ztapi_client.py
+++ b/tests/test_ztapi_client.py
@@ -1,0 +1,124 @@
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from collections.abc import Callable, Coroutine
+from typing import Any
+from ztapi_client import ZeroTierApiClient
+
+
+class TestZeroTierApiClient:
+    @pytest_asyncio.fixture
+    async def mock_server(  # type: ignore[misc]
+        self, aiohttp_server: Callable[[web.Application], Coroutine[Any, Any, TestServer]]
+    ) -> TestServer:
+        app = web.Application()
+        app.router.add_get("/api/v1/network/{network_id}", self.handle_get_network)
+        app.router.add_get("/api/v1/network/{network_id}/member", self.handle_get_members)
+        app.router.add_get("/api/v1/network/{network_id}/member/{member_id}", self.handle_get_member)
+        app.router.add_post("/api/v1/network/{network_id}/member/{member_id}", self.handle_tag_member)
+        server = await aiohttp_server(app)
+        return server
+
+    async def handle_get_network(self, request: web.Request) -> web.Response:
+        auth = request.headers.get("Authorization")
+        if auth != "token test-token":
+            return web.Response(status=401)
+        return web.json_response({
+            "id": "abc123",
+            "tagsByName": {
+                "status": {
+                    "id": 1,
+                    "default": 0,
+                    "enums": {"allowed": 0, "blocked": 1}
+                }
+            }
+        })
+
+    async def handle_get_members(self, request: web.Request) -> web.Response:
+        auth = request.headers.get("Authorization")
+        if auth != "token test-token":
+            return web.Response(status=401)
+        return web.json_response([
+            {
+                "config": {"id": "member1", "tags": [[1, 0]]},
+                "physicalAddress": "192.168.1.1",
+                "lastSeen": 1700000000000
+            },
+            {
+                "config": {"id": "member2", "tags": [[1, 1]]},
+                "physicalAddress": "192.168.1.2",
+                "lastSeen": 1700000001000
+            }
+        ])
+
+    async def handle_get_member(self, request: web.Request) -> web.Response:
+        auth = request.headers.get("Authorization")
+        if auth != "token test-token":
+            return web.Response(status=401)
+        member_id = request.match_info["member_id"]
+        if member_id == "notfound":
+            return web.Response(status=404)
+        return web.json_response({
+            "config": {"id": member_id, "tags": [[1, 0]]},
+            "physicalAddress": "192.168.1.1",
+            "lastSeen": 1700000000000
+        })
+
+    async def handle_tag_member(self, request: web.Request) -> web.Response:
+        auth = request.headers.get("Authorization")
+        if auth != "token test-token":
+            return web.Response(status=401)
+        return web.json_response({"status": "ok"})
+
+    @pytest.mark.asyncio
+    async def test_get_network_success(self, mock_server: TestServer) -> None:
+        async with ZeroTierApiClient("test-token") as client:
+            client._baseUrl = f"http://{mock_server.host}:{mock_server.port}/api/v1"
+            network = await client.get_network("abc123")
+            assert network is not None
+            assert network["id"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_get_network_unauthorized(self, mock_server: TestServer) -> None:
+        async with ZeroTierApiClient("wrong-token") as client:
+            client._baseUrl = f"http://{mock_server.host}:{mock_server.port}/api/v1"
+            network = await client.get_network("abc123")
+            assert network is None
+
+    @pytest.mark.asyncio
+    async def test_get_members_success(self, mock_server: TestServer) -> None:
+        async with ZeroTierApiClient("test-token") as client:
+            client._baseUrl = f"http://{mock_server.host}:{mock_server.port}/api/v1"
+            members = await client.get_members("abc123")
+            assert members is not None
+            assert len(members) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_member_success(self, mock_server: TestServer) -> None:
+        async with ZeroTierApiClient("test-token") as client:
+            client._baseUrl = f"http://{mock_server.host}:{mock_server.port}/api/v1"
+            member = await client.get_member("abc123", "member1")
+            assert member is not None
+            assert member["config"]["id"] == "member1"
+
+    @pytest.mark.asyncio
+    async def test_get_member_not_found(self, mock_server: TestServer) -> None:
+        async with ZeroTierApiClient("test-token") as client:
+            client._baseUrl = f"http://{mock_server.host}:{mock_server.port}/api/v1"
+            member = await client.get_member("abc123", "notfound")
+            assert member is None
+
+    @pytest.mark.asyncio
+    async def test_tag_member(self, mock_server: TestServer) -> None:
+        async with ZeroTierApiClient("test-token") as client:
+            client._baseUrl = f"http://{mock_server.host}:{mock_server.port}/api/v1"
+            network = {
+                "id": "abc123",
+                "tagsByName": {
+                    "status": {"id": 1, "enums": {"allowed": 0, "blocked": 1}}
+                }
+            }
+            member = {"config": {"id": "member1", "tags": [[1, 0]]}}
+            # Should not raise
+            await client.tag_member(network, member, "status", "blocked")


### PR DESCRIPTION
## Summary
- Add comprehensive test suite with 70 tests covering:
  - `bot_db.py`: Database operations, sightings, bans, cleanup
  - `ztapi_client.py`: API calls with mock aiohttp server
  - `discord_bot.py`: Formatting functions, player name validation, banlist checks
- Add pytest CI workflow that runs on PRs and pushes to main

## Test plan
- [x] All 70 tests pass locally
- [x] mypy passes on test files