### PR TITLE
Fix mypy kwargs type error on Python 3.14

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -229,9 +229,9 @@ async def dump_members(network: Any, members: Any, db: BotDatabase) -> None:
 
 
 class GamebotClient(discord.Client):
-    def __init__(self, *, intents: discord.Intents, **options: Any) -> None:
+    def __init__(self, *, intents: discord.Intents) -> None:
         intents.message_content = True
-        super().__init__(intents=intents, **options)
+        super().__init__(intents=intents)
         self._last_game_update: float | None = None
         self._last_zt_update: float | None = None
         self._last_log: float | None = None


### PR DESCRIPTION
## Summary
- Remove unused `**options` parameter from `GamebotClient.__init__` to fix type checking errors with stricter Python 3.14 type stubs

## Context
The CI workflow uses `python-version: '3.x'` which now resolves to Python 3.14. The stricter type checking in 3.14 causes mypy to reject `**options: Any` when passed to `discord.Client.__init__()`.

Since the `**options` parameter was never used (the client is instantiated with only `intents`), simply removing it is the cleanest fix.

## Test plan
- [x] Verified mypy passes locally
- [ ] CI mypy check passes